### PR TITLE
fix(lumen): replace config_path() with base_path()

### DIFF
--- a/src/LaravelAwsSecretsManagerServiceProvider.php
+++ b/src/LaravelAwsSecretsManagerServiceProvider.php
@@ -13,7 +13,7 @@ class LaravelAwsSecretsManagerServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/config.php' => config_path('aws-secrets-manager.php'),
+                __DIR__.'/../config/config.php' => base_path('config/aws-secrets-manager.php'),
             ], 'config');
         }
 


### PR DESCRIPTION
Lumen doesn't have `config_path` function but has `base_path`